### PR TITLE
fix (helm-chart-with-parameters): Whitespacing for Helm if conditional inserts empty line

### DIFF
--- a/helm-chart-with-parameters.md
+++ b/helm-chart-with-parameters.md
@@ -174,7 +174,7 @@ And add the conditional nodeport specification as follows:
   - port: 8080
     protocol: TCP
     targetPort: 8080
-    {{ if and (eq .Values.sentences.service.type "NodePort") .Values.sentences.service.nodePort -}}
+    {{- if and (eq .Values.sentences.service.type "NodePort") .Values.sentences.service.nodePort }}
     nodePort: {{ .Values.sentences.service.nodePort }}
     {{- end }}
 ```


### PR DESCRIPTION
When the conditional evaluates to false, a white line will be inserted instead of the property being added.

Before 
```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: sentences
    component: main
  name: sentence
spec:
  ports:
  - port: 8080
    protocol: TCP
    targetPort: 8080

  selector:
    app: sentences
    component: main
  type: NodePort
```

After:
```yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: sentences
    component: main
  name: sentence
spec:
  ports:
  - port: 8080
    protocol: TCP
    targetPort: 8080
  selector:
    app: sentences
    component: main
  type: NodePort
```