### PR TITLE
Increase resource settings for Prometheus to avoid being OOMKilled after several hours in a busy training cluster

### DIFF
--- a/resources/values-prometheus.yaml
+++ b/resources/values-prometheus.yaml
@@ -19,9 +19,9 @@ server:
   resources:
     limits:
       cpu: 250m
-      memory: 512Mi
+      memory: 1024Mi
     requests:
       cpu: 250m
-      memory: 256Mi
+      memory: 512Mi
   service:
     type: NodePort


### PR DESCRIPTION
Fixes https://github.com/Praqma/terraform-infrastructures/issues/45
